### PR TITLE
Add @types/node dev dep.

### DIFF
--- a/packages/astro-devtool-breakpoints/package.json
+++ b/packages/astro-devtool-breakpoints/package.json
@@ -31,6 +31,7 @@
         "@astrojs/mdx": "^2.0.3",
         "@astrojs/rss": "^4.0.1",
         "@astrojs/sitemap": "^3.0.4",
+        "@types/node": "^18.19.31",
         "astro": "^4.1.0",
         "rimraf": "^5.0.5",
         "typescript": "^5.3.3"


### PR DESCRIPTION
Thanks for the little utility.

I'm using it in a project and recently got a "missing types" error which I tracked down to this module.

I also noticed @astrojs/check (v0.3.4) has an available update: v0.5.10.